### PR TITLE
fix: Add Float64 dtype support for safetensors conversion

### DIFF
--- a/mlx-rs/src/array/safetensors.rs
+++ b/mlx-rs/src/array/safetensors.rs
@@ -90,6 +90,10 @@ impl<'a> TryFrom<&'a Array> for TensorView<'a> {
                     let bits: &[u16] = transmute(data);
                     cast_slice(bits)
                 },
+                Dtype::Float64 => {
+                    let data = value.as_slice::<f64>();
+                    cast_slice(data)
+                },
                 Dtype::Complex64 => return Err(ConversionError::MlxDtype(Dtype::Complex64)),
             }
         };


### PR DESCRIPTION
## Summary

- Add `Float64` (f64) dtype support in the `TryFrom<&Array> for TensorView` implementation

## Problem

Previously, attempting to convert an f64 MLX Array to a safetensors `TensorView` would fall through to the `Complex64` error case, making it impossible to save f64 arrays to safetensors files.

## Solution

Add the missing `Dtype::Float64` match arm that properly converts f64 arrays to safetensors format.

```rust
Dtype::Float64 => {
    let data = value.as_slice::<f64>();
    cast_slice(data)
},
```

## Use Case

This is needed for loading/saving certain model weights (e.g., some normalization layers) that use f64 precision.

## Test plan

- [x] Verified compilation
- [ ] Manual testing with f64 arrays

---

🤖 Generated with [Claude Code](https://claude.ai/code)