### PR TITLE
Fix metallib path for `cargo install` — use stable `~/.mlx/` directory

### DIFF
--- a/mlx-sys/build.rs
+++ b/mlx-sys/build.rs
@@ -1,7 +1,7 @@
 extern crate cmake;
 
 use cmake::Config;
-use std::{env, path::PathBuf, process::Command};
+use std::{env, fs, path::PathBuf, process::Command};
 
 /// Find the clang runtime library path dynamically using xcrun
 fn find_clang_rt_path() -> Option<String> {
@@ -44,6 +44,27 @@ fn find_clang_rt_path() -> Option<String> {
     None
 }
 
+/// Determine a stable directory for the MLX metallib that survives `cargo install`
+/// temp dir cleanup. Uses `~/.mlx/lib/v{version}/`.
+///
+/// When `cargo install` builds a crate, it uses a temporary directory that is
+/// deleted after the binary is copied. The CMake build bakes the metallib path
+/// into the binary via `-DMETAL_PATH=...`. If that path points to the temp dir,
+/// the binary fails at runtime with "Failed to load the default metallib".
+///
+/// By setting MLX_METAL_PATH to a stable home-directory location (and creating
+/// it before CMake runs so CMake can output the metallib there directly), the
+/// compiled-in METAL_PATH remains valid after the temp dir is cleaned up.
+#[cfg(feature = "metal")]
+fn stable_metallib_dir() -> PathBuf {
+    let version = env!("CARGO_PKG_VERSION");
+    let home = env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(home)
+        .join(".mlx")
+        .join("lib")
+        .join(format!("v{}", version))
+}
+
 fn build_and_link_mlx_c() {
     let mut config = Config::new("src/mlx-c");
     config.very_verbose(true);
@@ -69,6 +90,14 @@ fn build_and_link_mlx_c() {
     #[cfg(feature = "metal")]
     {
         config.define("MLX_BUILD_METAL", "ON");
+
+        // Point MLX_METAL_PATH to a stable location so the compiled-in
+        // METAL_PATH survives `cargo install` temp dir cleanup.
+        // Must create the directory BEFORE CMake runs because CMake
+        // outputs the compiled metallib directly to MLX_METAL_PATH.
+        let metallib_dir = stable_metallib_dir();
+        fs::create_dir_all(&metallib_dir).expect("Failed to create stable metallib directory");
+        config.define("MLX_METAL_PATH", metallib_dir.to_str().unwrap());
     }
 
     #[cfg(feature = "accelerate")]
@@ -90,6 +119,17 @@ fn build_and_link_mlx_c() {
     #[cfg(feature = "metal")]
     {
         println!("cargo:rustc-link-lib=framework=Metal");
+
+        // Verify CMake output the metallib to the stable location.
+        let metallib_dir = stable_metallib_dir();
+        let target_metallib = metallib_dir.join("mlx.metallib");
+        if !target_metallib.exists() {
+            eprintln!(
+                "cargo:warning=mlx.metallib not found at {}. \
+                 Runtime Metal operations may fail.",
+                target_metallib.display()
+            );
+        }
     }
 
     #[cfg(feature = "accelerate")]


### PR DESCRIPTION
## Problem

When a binary using mlx-rs is installed via `cargo install`, it fails at runtime:

```
MLX error: Failed to load the default metallib. library not found library not found library not found
```

`cargo install` builds in a temporary directory, then copies only the binary to `~/.cargo/bin/`. The CMake build bakes `METAL_PATH` as an absolute path to the metallib inside this temp dir. After install, the temp dir is deleted and the metallib is unreachable.

## Fix

Override `MLX_METAL_PATH` in the CMake config to point to a stable versioned directory: `~/.mlx/lib/v{mlx-sys-version}/`. The directory is created before CMake runs so CMake outputs the compiled metallib there directly. The compiled-in `METAL_PATH` now survives temp dir cleanup.

MLX's runtime metallib search order:
1. Co-located with binary → still works for local builds
2. Bundle resources → still works
3. SwiftPM bundle → still works
4. **`METAL_PATH` compiled-in fallback → now points to `~/.mlx/lib/v0.2.0/mlx.metallib`** ✅

## Testing

Tested with the [voice](https://github.com/rgbkrk/voicers) TTS crate:

```bash
# Patched build — metallib goes to stable location
cargo build --release -p voice
strings target/release/voice | grep metallib
# Shows: /Users/.../.mlx/lib/v0.2.0/mlx.metallib

ls ~/.mlx/lib/v0.2.0/mlx.metallib
# -rw-r--r--  84M  mlx.metallib

# Install and run — works even though build dir is gone
cargo install --path crates/voice-cli --force
voice -o /tmp/test.wav "hello"  # Success!
```

Fixes #327

Note: this PR is based on the v0.25.3 tag. Happy to rebase onto main if preferred — the `build.rs` on main has additional changes (clang_rt workaround) but the fix is the same.