### PR TITLE
docs(readme): bump MSRV claim to 1.85.0

### DIFF
--- a/mlx-rs/README.md
+++ b/mlx-rs/README.md
@@ -132,7 +132,7 @@ mlx-rs is currently in active development and can be used to run MLX models in R
 
 ## MSRV
 
-The minimum supported Rust version is 1.83.0.
+The minimum supported Rust version is 1.85.0.
 
 The MSRV is the minimum Rust version that can be used to compile each crate.
 


### PR DESCRIPTION
Workspace `Cargo.toml` has `rust-version = "1.85.0"` (`Cargo.toml:16`) and CI runs `cargo 1.85` (`.github/workflows/validate.yml`). The README's MSRV section still claimed 1.83.