### PR TITLE
docs: sync internal URLs from oxideai to oxiglade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ authors = [
     "David Chavez <david@dcvz.io>",
 ]
 
-repository = "https://github.com/oxideai/mlx-rs"
+repository = "https://github.com/oxiglade/mlx-rs"
 keywords = ["mlx", "deep-learning", "machine-learning"]
 categories = ["science"]
 license = "MIT OR Apache-2.0"
-documentation = "https://oxideai.github.io/mlx-rs/mlx_rs/"
+documentation = "https://oxiglade.github.io/mlx-rs/mlx_rs/"
 rust-version = "1.85.0"
 
 [workspace]

--- a/mlx-rs/README.md
+++ b/mlx-rs/README.md
@@ -5,8 +5,8 @@ Rust bindings for Apple's mlx machine learning library.
 
 [![Discord](https://img.shields.io/discord/1176807732473495552.svg?color=7289da&&logo=discord)](https://discord.gg/jZvTsxDX49)
 [![Current Crates.io Version](https://img.shields.io/crates/v/mlx-rs.svg)](https://crates.io/crates/mlx-rs)
-[![Documentation](https://img.shields.io/badge/docs-latest-blue)](https://oxideai.github.io/mlx-rs/mlx_rs/)
-[![Test Status](https://github.com/oxideai/mlx-rs/actions/workflows/validate.yml/badge.svg)](https://github.com/oxideai/mlx-rs/actions/workflows/validate.yml)
+[![Documentation](https://img.shields.io/badge/docs-latest-blue)](https://oxiglade.github.io/mlx-rs/mlx_rs/)
+[![Test Status](https://github.com/oxiglade/mlx-rs/actions/workflows/validate.yml/badge.svg)](https://github.com/oxiglade/mlx-rs/actions/workflows/validate.yml)
 [![Blaze](https://runblaze.dev/gh/307493885959233117281096297203102330146/badge.svg)](https://runblaze.dev)
 [![Rust Version](https://img.shields.io/badge/Rust-1.82.0+-blue)](https://releases.rs/docs/1.82.0)
 ![license](https://shields.io/badge/license-MIT%2FApache--2.0-blue)
@@ -33,7 +33,7 @@ _[Blaze](https://runblaze.dev) supports this project by providing ultra-fast App
 
 ## Documentation
 
-Due to known limitation of docsrs, we are hosting the documentation on github pages [here](https://oxideai.github.io/mlx-rs/mlx_rs/).
+Due to known limitation of docsrs, we are hosting the documentation on github pages [here](https://oxiglade.github.io/mlx-rs/mlx_rs/).
 
 ## Features
 

--- a/mlx-rs/src/lib.rs
+++ b/mlx-rs/src/lib.rs
@@ -52,7 +52,7 @@
 //!
 //! ## Function and Graph Transformations
 //!
-//! TODO: https://github.com/oxideai/mlx-rs/issues/214
+//! TODO: https://github.com/oxiglade/mlx-rs/issues/214
 //!
 //! TODO: also document that all `Array` in the args for function
 //!       transformations

--- a/mlx-rs/src/transforms/mod.rs
+++ b/mlx-rs/src/transforms/mod.rs
@@ -23,7 +23,7 @@
 //! argument to compute the gradient with respect to, use
 //! [`grad_with_argnums()`] or [`value_and_grad_with_argnums()`].
 //!
-//! TODO: update the example once https://github.com/oxideai/mlx-rs/pull/218 is merged
+//! TODO: update the example once https://github.com/oxiglade/mlx-rs/pull/218 is merged
 //!
 //! ```rust,ignore
 //! use mlx_rs::{Array, error::Result, transforms::grad};


### PR DESCRIPTION
The org was renamed around 2026-05-18. GitHub still redirects, but the in-tree URLs (`Cargo.toml` `repository` and `documentation` fields, README badges, in-source TODO links) still point at `oxideai`. Pure docs/metadata change, no code touched.