### PR TITLE
Bump mlx-c to v0.6.0 (MLX 0.31.1)

### DIFF
--- a/mlx-rs/src/ops/quantization.rs
+++ b/mlx-rs/src/ops/quantization.rs
@@ -63,6 +63,7 @@ pub fn quantize_device(
             group_size,
             bits,
             DEFAULT_MODE.as_ptr(),
+            /* global_scale */ mlx_sys::mlx_array_new(),
             stream.as_ref().as_ptr(),
         )
     })?;
@@ -151,6 +152,7 @@ pub fn dequantize_device<'a>(
             group_size,
             bits,
             DEFAULT_MODE.as_ptr(),
+            /* global_scale */ mlx_sys::mlx_array_new(),
             optional_dtype_none(),
             stream.as_ref().as_ptr(),
         )


### PR DESCRIPTION
## Summary

- Bump the `mlx-sys/src/mlx-c` submodule from v0.5.0 (MLX 0.30.6) to **v0.6.0 (MLX 0.31.1)**
- Adapt `quantize`/`dequantize` to the new C signatures: MLX 0.31 adds an optional `global_scale` array parameter to both (used by the new two-level-scaled MXFP4 path). A fresh `mlx_array_new()` handle is passed, which the C API treats as null — matching the existing convention for optional arrays (e.g. `biases` in `quantized_matmul`).

## Motivation

MLX 0.30.6's scheduler deadlocks on large GDN-hybrid models on smaller unified-memory boxes (repro: Qwen3.8-27B 4-bit, 15.2 GiB checkpoint, M4 32 GB — first wide prefill wedges `eval_impl` on a condition variable forever; an `io_connect_method` GPU submission never completes). 0.31.1 fixes this class. Details and a sample backtrace: measured while porting the model to the higgs inference server.

## Testing

- `cargo build` clean for `mlx-sys` and `mlx-rs`
- Full model load + serve + MTP speculative decode verified on M4 (macOS 26), including the `quantize`/`dequantize` paths exercised by checkpoint loading
- No other API surface changed between 0.30.6 → 0.31.1 in the C bindings used by mlx-rs

Follows the pattern of #98 (v0.4.1 → v0.5.0 bump).