### PR TITLE
Community PR adoptions: rope shape, metallib distribution, padded-buffer guards

### DIFF
--- a/ledger/rust-api-baseline.json
+++ b/ledger/rust-api-baseline.json
@@ -4330,6 +4330,21 @@
       }
     },
     {
+      "kind": "module",
+      "path": "mlx_rs::metal",
+      "signature": "pub mod metal"
+    },
+    {
+      "kind": "function",
+      "path": "mlx_rs::metal::metallib_path",
+      "signature": "pub fn metallib_path () -> Result < String >"
+    },
+    {
+      "kind": "function",
+      "path": "mlx_rs::metal::set_metallib_path",
+      "signature": "pub fn set_metallib_path (path : impl AsRef < str >) -> Result < () >"
+    },
+    {
       "kind": "macro",
       "path": "mlx_rs::min",
       "signature": "macro_rules! min",

--- a/ledger/supported-feature-matrix.json
+++ b/ledger/supported-feature-matrix.json
@@ -24,6 +24,19 @@
       }
     },
     {
+      "feature": "metal-library-path",
+      "canonical_path": "mlx_rs::metal",
+      "symbols": {
+        "mlx_metal_get_metallib_path": "mlx_rs::metal::metallib_path",
+        "mlx_metal_set_metallib_path": "mlx_rs::metal::set_metallib_path"
+      },
+      "evidence": {
+        "api": "mlx-rs/src/metal.rs",
+        "distribution": "mlx-sys/build.rs",
+        "test": "mlx-rs/src/metal.rs#metallib_path_roundtrips"
+      }
+    },
+    {
       "feature": "slice-update",
       "canonical_path": "mlx_rs::ops::indexing::TryIndexUpdateOp",
       "symbols": {

--- a/ledger/target-delta-classification.json
+++ b/ledger/target-delta-classification.json
@@ -809,8 +809,11 @@
         "name": "mlx_metal_get_metallib_path",
         "signature": "fn(* mut mlx_string)->:: std :: os :: raw :: c_int"
       },
-      "disposition": "deferred",
-      "rationale": "target symbol has no Rust wrapper at the old pin"
+      "disposition": "wrapped",
+      "rust_path": "mlx_rs::metal::metallib_path",
+      "evidence": [
+        "api:test:mlx-rs/src/metal.rs#metallib_path_is_non_empty"
+      ]
     },
     {
       "change": "added",
@@ -821,8 +824,11 @@
         "name": "mlx_metal_set_metallib_path",
         "signature": "fn(* const :: std :: os :: raw :: c_char)->:: std :: os :: raw :: c_int"
       },
-      "disposition": "deferred",
-      "rationale": "target symbol has no Rust wrapper at the old pin"
+      "disposition": "wrapped",
+      "rust_path": "mlx_rs::metal::set_metallib_path",
+      "evidence": [
+        "api:test:mlx-rs/src/metal.rs#metallib_path_roundtrips"
+      ]
     },
     {
       "change": "added",

--- a/mlx-rs/src/lib.rs
+++ b/mlx-rs/src/lib.rs
@@ -295,6 +295,8 @@ pub mod fft;
 pub mod io;
 pub mod linalg;
 pub mod losses;
+#[cfg(feature = "metal")]
+pub mod metal;
 pub mod module;
 pub mod nested;
 pub mod nn;

--- a/mlx-rs/src/metal.rs
+++ b/mlx-rs/src/metal.rs
@@ -1,0 +1,108 @@
+//! Metal-specific runtime configuration.
+
+use std::ffi::{CStr, CString};
+
+use crate::{
+    error::{Exception, Result},
+    utils::SUCCESS,
+};
+
+struct StringHandle {
+    raw: mlx_sys::mlx_string,
+}
+
+impl StringHandle {
+    fn new() -> Self {
+        Self {
+            raw: unsafe { mlx_sys::mlx_string_new() },
+        }
+    }
+
+    fn to_string(&self) -> Result<String> {
+        let data = unsafe { mlx_sys::mlx_string_data(self.raw) };
+        if data.is_null() {
+            return Err(Exception::custom("MLX returned an empty string handle"));
+        }
+        unsafe { CStr::from_ptr(data) }
+            .to_str()
+            .map(str::to_owned)
+            .map_err(|error| Exception::custom(error.to_string()))
+    }
+}
+
+impl Drop for StringHandle {
+    fn drop(&mut self) {
+        let _ = unsafe { mlx_sys::mlx_string_free(self.raw) };
+    }
+}
+
+fn install_error_handler() {
+    crate::error::INIT_ERR_HANDLER.call_once(crate::error::setup_mlx_error_handler);
+}
+
+fn status_result(status: i32, operation: &str) -> Result<()> {
+    if status == SUCCESS {
+        Ok(())
+    } else {
+        Err(crate::error::exception_from_status(status, operation))
+    }
+}
+
+/// Returns the path used to load the default Metal library.
+pub fn metallib_path() -> Result<String> {
+    install_error_handler();
+    let mut path = StringHandle::new();
+    let status = unsafe { mlx_sys::mlx_metal_get_metallib_path(&mut path.raw) };
+    status_result(status, "reading the Metal library path")?;
+    path.to_string()
+}
+
+/// Sets the path used by subsequent Metal initialization.
+///
+/// This changes process-global MLX state and can affect every thread that initializes Metal
+/// afterward.
+pub fn set_metallib_path(path: impl AsRef<str>) -> Result<()> {
+    install_error_handler();
+    let path = CString::new(path.as_ref()).map_err(|error| Exception::custom(error.to_string()))?;
+    let status = unsafe { mlx_sys::mlx_metal_set_metallib_path(path.as_ptr()) };
+    status_result(status, "setting the Metal library path")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::{metallib_path, set_metallib_path};
+
+    static METALLIB_PATH: Mutex<()> = Mutex::new(());
+
+    struct RestorePath(String);
+
+    impl Drop for RestorePath {
+        fn drop(&mut self) {
+            set_metallib_path(&self.0).expect("restore metallib path");
+        }
+    }
+
+    #[test]
+    fn metallib_path_is_non_empty() {
+        let _guard = METALLIB_PATH.lock().expect("lock metallib path");
+        let original = metallib_path().unwrap();
+        let _restore = RestorePath(original);
+        set_metallib_path("mlx-rs-metallib-path-test").unwrap();
+
+        assert!(!metallib_path().unwrap().is_empty());
+    }
+
+    #[test]
+    fn metallib_path_roundtrips() {
+        let _guard = METALLIB_PATH.lock().expect("lock metallib path");
+        let original = metallib_path().unwrap();
+        let _restore = RestorePath(original.clone());
+        let temporary = format!("{original}.mlx-rs-roundtrip");
+
+        set_metallib_path(&temporary).unwrap();
+
+        assert_eq!(metallib_path().unwrap(), temporary);
+    }
+}

--- a/mlx-rs/src/nn/positional_encoding.rs
+++ b/mlx-rs/src/nn/positional_encoding.rs
@@ -119,9 +119,7 @@ where
 
     fn forward(&mut self, input: Input) -> Result<Self::Output, Self::Error> {
         let RopeInput { x, offset } = input.into();
-        let shape = x.shape();
-        let x = x.reshape(&[-1, x.dim(-2), x.dim(-1)])?;
-        let x = crate::fast::rope(
+        crate::fast::rope(
             x,
             self.dimensions,
             self.traditional,
@@ -129,8 +127,7 @@ where
             self.scale,
             offset,
             None,
-        )?;
-        x.reshape(shape)
+        )
     }
 
     fn training_mode(&mut self, _mode: bool) {}
@@ -460,6 +457,43 @@ mod tests {
             116.80096435546875,
             abs <= 2.3360192871093752
         );
+    }
+
+    #[test]
+    fn test_rope_single_position_matches_broadcast_head() {
+        let head = [0.1_f32, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8];
+        let mut heads = Vec::with_capacity(32);
+        for _ in 0..4 {
+            heads.extend_from_slice(&head);
+        }
+        let input = crate::Array::from_slice(&heads, &[1, 4, 1, 8]);
+        let single_head = crate::Array::from_slice(&head, &[1, 1, 1, 8]);
+        let mut rope = Rope::new(8);
+
+        let output = rope.forward((&input, 1)).unwrap();
+        let single_output = rope.forward((&single_head, 1)).unwrap();
+        let expected = crate::ops::broadcast_to(&single_output, &[1, 4, 1, 8]).unwrap();
+        let max_head_difference = output
+            .subtract(&expected)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max(None)
+            .unwrap()
+            .item_exact::<f32>();
+
+        assert_eq!(output.shape(), &[1, 4, 1, 8]);
+        assert!(max_head_difference < 1e-5);
+
+        let rotation = single_output
+            .subtract(&single_head)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max(None)
+            .unwrap()
+            .item_exact::<f32>();
+        assert!(rotation > 1e-4);
     }
 
     // The unit test below is adapted from the swift binding at:

--- a/mlx-sys/README.md
+++ b/mlx-sys/README.md
@@ -4,3 +4,15 @@ Rust bindings to the mlx-c API. Generated using bindgen.
 
 The crate version is independent of its native source tuple. This revision targets mlx-c
 `c74db5307cc8ce122f48d97ef951b30578674e7f`, whose CMake configuration pins MLX `v0.32.2`.
+
+## Metal library location
+
+Metal builds place `mlx.metallib` in `~/.mlx/lib/<mlx-c-key>/`, where `<mlx-c-key>` is the
+first 12 characters of the pinned mlx-c commit. Packaged source without Git metadata uses a
+deterministic hash of the mlx-c headers and CMake configuration instead. The stable location
+allows binaries produced by `cargo install` to keep loading the library after Cargo removes its
+temporary build directory.
+
+Set `MLX_RS_METAL_PATH` to use a different directory verbatim as CMake's `MLX_METAL_PATH`.
+When this override is set, the build does not read or write `HOME`, which supports sandboxed and
+Nix builds.

--- a/mlx-sys/build.rs
+++ b/mlx-sys/build.rs
@@ -1,7 +1,14 @@
 extern crate cmake;
 
 use cmake::Config;
-use std::{env, path::PathBuf, process::Command};
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[cfg(feature = "metal")]
+use std::fs;
 
 #[path = "../xtask/src/bindgen_config.rs"]
 mod bindgen_config;
@@ -47,8 +54,62 @@ fn find_clang_rt_path() -> Option<String> {
     None
 }
 
+#[cfg(feature = "metal")]
+fn mlx_c_key(mlx_c_root: &Path) -> String {
+    if mlx_c_root.join(".git").exists() {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(mlx_c_root)
+            .args(["rev-parse", "HEAD"])
+            .output();
+        if let Ok(output) = output {
+            if output.status.success() {
+                let commit = String::from_utf8_lossy(&output.stdout);
+                let commit = commit.trim();
+                if commit.len() >= 12 && commit.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+                    return commit[..12].to_owned();
+                }
+            }
+        }
+    }
+
+    let mut files = bindgen_config::discover_headers(mlx_c_root)
+        .expect("Unable to discover mlx-c headers for the metallib key");
+    files.push(mlx_c_root.join("CMakeLists.txt"));
+    files.sort();
+
+    let mut hash = 0xcbf29ce484222325_u64;
+    for file in files {
+        let relative = file.strip_prefix(mlx_c_root).unwrap_or(&file);
+        for byte in relative.to_string_lossy().bytes().chain([0]) {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        for byte in fs::read(&file).expect("Unable to hash mlx-c source for the metallib key") {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+    }
+    format!("{hash:016x}")[..12].to_owned()
+}
+
+#[cfg(feature = "metal")]
+fn metallib_dir(mlx_c_root: &Path) -> PathBuf {
+    if let Some(path) = env::var_os("MLX_RS_METAL_PATH") {
+        return PathBuf::from(path);
+    }
+
+    let home =
+        env::var_os("HOME").expect("HOME must be set when MLX_RS_METAL_PATH is not provided");
+    PathBuf::from(home)
+        .join(".mlx")
+        .join("lib")
+        .join(mlx_c_key(mlx_c_root))
+}
+
 fn build_and_link_mlx_c() {
-    let mut config = Config::new("src/mlx-c");
+    let mlx_c_root = Path::new("src/mlx-c");
+    let mut config = Config::new(mlx_c_root);
     config.very_verbose(true);
     config.define("CMAKE_INSTALL_PREFIX", ".");
 
@@ -72,6 +133,9 @@ fn build_and_link_mlx_c() {
     #[cfg(feature = "metal")]
     {
         config.define("MLX_BUILD_METAL", "ON");
+        let metallib_dir = metallib_dir(mlx_c_root);
+        fs::create_dir_all(&metallib_dir).expect("Unable to create the MLX metallib directory");
+        config.define("MLX_METAL_PATH", &metallib_dir);
     }
 
     #[cfg(feature = "accelerate")]
@@ -100,6 +164,13 @@ fn build_and_link_mlx_c() {
     #[cfg(feature = "metal")]
     {
         println!("cargo:rustc-link-lib=framework=Metal");
+        let metallib = metallib_dir(mlx_c_root).join("mlx.metallib");
+        if !metallib.exists() {
+            println!(
+                "cargo:warning=mlx.metallib was not created at {}; Metal operations may fail at runtime",
+                metallib.display()
+            );
+        }
     }
 
     #[cfg(feature = "accelerate")]
@@ -117,6 +188,7 @@ fn build_and_link_mlx_c() {
 }
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=MLX_RS_METAL_PATH");
     build_and_link_mlx_c();
 
     let mlx_c_root = PathBuf::from("src/mlx-c");

--- a/mlx-tests/tests/padded_buffer.rs
+++ b/mlx-tests/tests/padded_buffer.rs
@@ -1,0 +1,54 @@
+use mlx_rs::{
+    ops::{
+        concatenate,
+        indexing::{TryIndexMutOp, TryIndexOp},
+    },
+    Array,
+};
+
+fn prefix() -> Array {
+    Array::arange::<_, f32>(0, 4_080, None)
+        .unwrap()
+        .reshape(&[1, 2, 510, 4])
+        .unwrap()
+}
+
+fn token() -> Array {
+    Array::arange::<_, f32>(9_000, 9_008, None)
+        .unwrap()
+        .reshape(&[1, 2, 1, 4])
+        .unwrap()
+}
+
+fn assert_appended_token(buffer: &Array) {
+    // Integer indexing into the padded buffer yields a non-contiguous view, so
+    // compare arrays instead of extracting a slice.
+    let slot = buffer.try_index((.., .., 510, ..)).unwrap();
+    let expected = token().try_index((.., .., 0, ..)).unwrap();
+    assert!(
+        slot.eq_exact(&expected).unwrap(),
+        "appended token corrupted"
+    );
+}
+
+#[test]
+fn concatenated_token_survives_capacity_padding() {
+    let padding = Array::zeros::<f32>(&[1, 2, 1, 4]).unwrap();
+    let padded = concatenate(&[prefix(), token(), padding], -2).unwrap();
+    let live = padded.try_index((.., .., ..511, ..)).unwrap();
+
+    assert_eq!(padded.shape(), &[1, 2, 512, 4]);
+    assert_appended_token(&live);
+}
+
+#[test]
+fn indexed_token_survives_capacity_padding() {
+    let mut buffer = Array::zeros::<f32>(&[1, 2, 512, 4]).unwrap();
+    buffer.try_index_mut((.., .., ..510, ..), prefix()).unwrap();
+    buffer
+        .try_index_mut((.., .., 510..511, ..), token())
+        .unwrap();
+    let live = buffer.try_index((.., .., ..511, ..)).unwrap();
+
+    assert_appended_token(&live);
+}


### PR DESCRIPTION
Lands our implementations of the three still-relevant community PRs, verified against the pinned oracle:

- **RoPE on input shape** (supersedes #357, thanks @sergey-scherbina): apply `fast::rope` directly on the 4D input like Python mlx_lm, dropping two reshapes per decode step, plus an all-heads-rotate invariance regression test. Note: the upstream fast-rope single-position corruption that motivated the original PR is already fixed at our MLX 0.32.2 pin (verified 3D == 4D bit-for-bit) — this is alignment and simplification, not a live corruption fix.
- **Durable metallib path** (supersedes #328, thanks @rgbkrk): fixes `cargo install` runtime failure (#327) by pointing MLX_METAL_PATH at `~/.mlx/lib/<mlx-c-commit-key>/` — keyed by the mlx-c pin (not the crate version, which can go stale) with a deterministic content-hash fallback and an `MLX_RS_METAL_PATH` override so sandboxed builds never write $HOME. Also wraps `metal::metallib_path` / `metal::set_metallib_path` (2 more deferred symbols → wrapped; tally now 18).
- **Padded-buffer regression guards** (supersedes #338, thanks @i386): the KV-cache padded-capacity corruption it documented is fixed at 0.32.2 (verified in pinned Python and through the new TryIndexMutOp path); permanent regression tests now pin both the concat+pad+view and indexed-write paths so an upstream regression cannot return silently.

Evidence: full suite 1073/0, FFI leak gate pass (0 bytes), verify-ledger + verify-oracle-boundary pass, API baseline blessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)