### PR TITLE
Docs corrections + RNG thread-exit leak regression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ authors = [
     "David Chavez <david@dcvz.io>",
 ]
 
-repository = "https://github.com/oxideai/mlx-rs"
+repository = "https://github.com/oxiglade/mlx-rs"
 keywords = ["mlx", "deep-learning", "machine-learning"]
 categories = ["science"]
 license = "MIT OR Apache-2.0"
-documentation = "https://oxideai.github.io/mlx-rs/mlx_rs/"
+documentation = "https://oxiglade.github.io/mlx-rs/mlx_rs/"
 rust-version = "1.88.0"
 
 [workspace]

--- a/mlx-rs/README.md
+++ b/mlx-rs/README.md
@@ -5,10 +5,10 @@ Rust bindings for Apple's mlx machine learning library.
 
 [![Discord](https://img.shields.io/discord/1176807732473495552.svg?color=7289da&&logo=discord)](https://discord.gg/jZvTsxDX49)
 [![Current Crates.io Version](https://img.shields.io/crates/v/mlx-rs.svg)](https://crates.io/crates/mlx-rs)
-[![Documentation](https://img.shields.io/badge/docs-latest-blue)](https://oxideai.github.io/mlx-rs/mlx_rs/)
-[![Test Status](https://github.com/oxideai/mlx-rs/actions/workflows/validate.yml/badge.svg)](https://github.com/oxideai/mlx-rs/actions/workflows/validate.yml)
+[![Documentation](https://img.shields.io/badge/docs-latest-blue)](https://oxiglade.github.io/mlx-rs/mlx_rs/)
+[![Test Status](https://github.com/oxiglade/mlx-rs/actions/workflows/validate.yml/badge.svg)](https://github.com/oxiglade/mlx-rs/actions/workflows/validate.yml)
 [![Blaze](https://runblaze.dev/gh/307493885959233117281096297203102330146/badge.svg)](https://runblaze.dev)
-[![Rust Version](https://img.shields.io/badge/Rust-1.82.0+-blue)](https://releases.rs/docs/1.82.0)
+[![Rust Version](https://img.shields.io/badge/Rust-1.88.0+-blue)](https://releases.rs/docs/1.88.0)
 ![license](https://shields.io/badge/license-MIT%2FApache--2.0-blue)
 
 > **⚠️ Project is in active development - contributors welcome!**
@@ -33,7 +33,7 @@ _[Blaze](https://runblaze.dev) supports this project by providing ultra-fast App
 
 ## Documentation
 
-Due to known limitation of docsrs, we are hosting the documentation on github pages [here](https://oxideai.github.io/mlx-rs/mlx_rs/).
+Due to known limitation of docsrs, we are hosting the documentation on github pages [here](https://oxiglade.github.io/mlx-rs/mlx_rs/).
 
 ## Features
 
@@ -132,7 +132,7 @@ mlx-rs is currently in active development and can be used to run MLX models in R
 
 ## MSRV
 
-The minimum supported Rust version is 1.83.0.
+The minimum supported Rust version is 1.88.0.
 
 The MSRV is the minimum Rust version that can be used to compile each crate.
 

--- a/mlx-rs/src/lib.rs
+++ b/mlx-rs/src/lib.rs
@@ -60,7 +60,7 @@
 //!
 //! ## Function and Graph Transformations
 //!
-//! TODO: https://github.com/oxideai/mlx-rs/issues/214
+//! TODO: https://github.com/oxiglade/mlx-rs/issues/214
 //!
 //! TODO: also document that all `Array` in the args for function
 //!       transformations

--- a/mlx-rs/src/transforms/mod.rs
+++ b/mlx-rs/src/transforms/mod.rs
@@ -28,7 +28,7 @@
 //! A panic in a Rust transform closure is caught before it reaches MLX. After MLX returns through
 //! the C ABI, the panic resumes in Rust with its original payload.
 //!
-//! TODO: update the example once https://github.com/oxideai/mlx-rs/pull/218 is merged
+//! TODO: update the example once https://github.com/oxiglade/mlx-rs/pull/218 is merged
 //!
 //! ```rust,ignore
 //! use mlx_rs::{Array, error::Result, transforms::grad};

--- a/mlx-tests/tests/ffi_safety.rs
+++ b/mlx-tests/tests/ffi_safety.rs
@@ -514,6 +514,30 @@ fn run_concurrent_invoke_errors_child() {
     join_workers(handles);
 }
 
+#[test]
+fn implicit_rng_state_is_released_at_thread_exit() {
+    const WORKERS: usize = 8;
+    const OPERATIONS: usize = 25;
+
+    let handles = (0..WORKERS)
+        .map(|_| {
+            thread::spawn(|| {
+                for _ in 0..OPERATIONS {
+                    let result = mlx_rs::random::normal::<f32>(&[2, 3], None, None, None).unwrap();
+                    result.eval().unwrap();
+                    assert_eq!(result.shape(), &[2, 3]);
+                    assert!(result
+                        .as_slice::<f32>()
+                        .iter()
+                        .all(|value| value.is_finite()));
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    join_workers(handles);
+}
+
 fn mismatched_arrays(worker: usize) -> (Array, Array, usize, usize) {
     let lhs_len = worker + 3;
     let rhs_len = worker + ERROR_WORKERS + 3;


### PR DESCRIPTION
Quick wins mined from the open-PR triage:

- **MSRV claims corrected to 1.88.0** in both READMEs (badge said 1.82.0+, text said 1.83.0, Cargo.toml says 1.88.0 and CI tests 1.88.0) — supersedes #353, thanks @fiorelorenzo for flagging.
- **Remaining `oxideai` → `oxiglade` references** fixed repo-wide — supersedes #354.
- **RNG thread-exit leak regression test** in the leak-gated ffi_safety binary: 8 threads × 25 implicit-key RNG ops each, pinning that per-thread RNG state (made thread-local during the mlx-c bump after a real cross-thread stream bug) releases every handle at thread exit — adopts the regression idea from #360, thanks @ilblackdragon.

Verified: ffi_safety 18/18, FFI leak gate pass (0 bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)