### PR TITLE
Seed the SGD convergence test

### DIFF
--- a/mlx-rs/src/nn/container.rs
+++ b/mlx-rs/src/nn/container.rs
@@ -147,6 +147,9 @@ mod tests {
         let m = array!(0.25);
         let b = array!(0.75);
 
+        // Unseeded draws occasionally start at a loss the 100 SGD steps do not
+        // beat, so pin the trajectory.
+        crate::random::seed(71).unwrap();
         let mut model = Sequential::new()
             .append(Linear::new(input_dim, hidden_dim).unwrap())
             .append(Linear::new(hidden_dim, output_dim).unwrap());


### PR DESCRIPTION
The sequential-linear SGD test draws unseeded random data and asserts the first loss beats the last — an unlucky draw fails it intermittently (it just hit #293's CI run, which had nothing to do with the failure). Seeding pins the trajectory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)